### PR TITLE
verify: separate roots from intermediates, gate IsCA (closes #21)

### DIFF
--- a/verify/verifymudsig.go
+++ b/verify/verifymudsig.go
@@ -17,7 +17,8 @@
 package main
 
 /*
-verifymudsig verifies a MUD signature on a file, with a given cert set.
+verifymudsig verifies a MUD signature on a file against a configured
+set of trust anchors.
 
 Usage:
 
@@ -25,78 +26,152 @@ Usage:
 
 The flags are as follows:
 
-  -cert string
-        Name of file containing one or more signing certs
-        (default "signer.pem")
+  -ca string
+        Path to a PEM file containing one or more trust anchor
+        (CA) certificates. Each certificate in this file MUST
+        carry IsCA=true; any other certificate is rejected.
+        Required. (default "ca.pem")
+  -int string
+        Optional path to a PEM file containing intermediate
+        certificates that may appear in the signer's chain.
+        Not used as trust anchors.
   -sig string
-        Name of file containing DER signature. (default "mudfile.p7s")
-
+        Name of file containing DER signature. (default
+        "mudfile.p7s")
 */
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	cms "github.com/github/smimesign/ietf-cms"
 )
 
-func main() {
-	certfile := flag.String("cert", "signer.pem",
-		"Name of file containing one or more certificates, including a trust anchor (CA Cert)")
-	sigfile := flag.String("sig", "mudfile.p7s",
-		"name of file containing DER signature.")
-	flag.Parse()
-	// read in certs
-	pemfile, err := os.ReadFile(*certfile)
+// loadPEMCerts reads path and returns every CERTIFICATE block parsed.
+// Non-CERTIFICATE blocks are silently skipped (e.g. PRIVATE KEY).
+// Returns an error if path is empty, unreadable, contains no
+// CERTIFICATE blocks, or any block fails to parse.
+func loadPEMCerts(path string) ([]*x509.Certificate, error) {
+	if path == "" {
+		return nil, errors.New("empty path")
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	block, rest := pem.Decode(pemfile)
-
-	if block == nil {
-		log.Fatal("no certs available")
-	}
-
-	opts := x509.VerifyOptions{
-		Roots:     x509.NewCertPool(),
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
-	}
-
-	for (rest != nil) && (block != nil) {
+	var certs []*x509.Certificate
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("parse certificate in %s: %w", path, err)
 		}
-		opts.Roots.AddCert(cert)
-		block, rest = pem.Decode(rest)
+		certs = append(certs, cert)
 	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no CERTIFICATE blocks found in %s", path)
+	}
+	return certs, nil
+}
 
-	sig, err := os.ReadFile(*sigfile)
+// buildPools loads CA and (optional) intermediate certificates and
+// builds the corresponding pools. Every certificate supplied via caPath
+// MUST have IsCA=true; supplying a non-CA certificate as a trust anchor
+// is the bug fixed by issue #21 and is rejected here.
+func buildPools(caPath, intPath string) (roots, intermediates *x509.CertPool, err error) {
+	cas, err := loadPEMCerts(caPath)
 	if err != nil {
-		log.Fatal(err)
+		return nil, nil, fmt.Errorf("ca: %w", err)
+	}
+	roots = x509.NewCertPool()
+	for _, c := range cas {
+		if !c.IsCA {
+			return nil, nil, fmt.Errorf("ca: certificate %q is not a CA (IsCA=false)", c.Subject)
+		}
+		roots.AddCert(c)
 	}
 
-	if flag.NArg() != 1 {
-		log.Fatal("No data file specified: provide filename of mud file to be verified.")
+	intermediates = x509.NewCertPool()
+	if intPath != "" {
+		ints, err := loadPEMCerts(intPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("intermediates: %w", err)
+		}
+		for _, c := range ints {
+			intermediates.AddCert(c)
+		}
 	}
+	return roots, intermediates, nil
+}
 
-	mudfile, err := os.ReadFile(flag.Args()[0])
+// verify performs the full signature check. It is split out from main
+// so that tests can exercise it without spawning a process.
+//
+// NOTE: KeyUsages is intentionally left as ExtKeyUsageAny because the
+// MUD signer certificates produced by this repository's MakeSignerCert
+// do not currently carry an Extended Key Usage extension. Once
+// MakeSignerCert is updated to set ExtKeyUsageEmailProtection, this
+// should be tightened accordingly.
+func verify(caPath, intPath, sigPath, mudPath string, now time.Time) error {
+	roots, intermediates, err := buildPools(caPath, intPath)
 	if err != nil {
-		log.Fatal(err)
+		return err
+	}
+
+	sig, err := os.ReadFile(sigPath)
+	if err != nil {
+		return fmt.Errorf("read sig %s: %w", sigPath, err)
+	}
+	mudfile, err := os.ReadFile(mudPath)
+	if err != nil {
+		return fmt.Errorf("read mud file %s: %w", mudPath, err)
 	}
 
 	sd, err := cms.ParseSignedData(sig)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("parse signature: %w", err)
 	}
-	if err != nil {
-		log.Fatal(err)
+
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		CurrentTime:   now,
 	}
 	if _, err := sd.VerifyDetached(mudfile, opts); err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	caFlag := flag.String("ca", "ca.pem",
+		"Path to PEM file with one or more trust anchor (CA) certificates")
+	intFlag := flag.String("int", "",
+		"Optional path to PEM file with intermediate certificates")
+	sigFlag := flag.String("sig", "mudfile.p7s",
+		"Path to DER signature file")
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		log.Fatal("verifymudsig: provide exactly one MUD file path to verify")
+	}
+
+	if err := verify(*caFlag, *intFlag, *sigFlag, flag.Args()[0], time.Now()); err != nil {
+		log.Fatalf("verifymudsig: %v", err)
 	}
 	fmt.Println("Ok.")
 }

--- a/verify/verifymudsig_test.go
+++ b/verify/verifymudsig_test.go
@@ -1,0 +1,183 @@
+// Copyright 2024 Cisco Systems, Inc. and Affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/iot-onboarding/mudcerts"
+)
+
+// fixtures holds an in-memory set of generated artifacts plus the
+// directory containing PEM/DER files on disk.
+type fixtures struct {
+	dir       string
+	caPath    string
+	signerPEM string // signer cert PEM written to disk (for use as -ca in negative tests)
+	sigPath   string
+	mudPath   string
+
+	// retained for advanced tests that want to mutate things.
+	caCert      *x509.Certificate
+	caKey       *ecdsa.PrivateKey
+	signerCert  *x509.Certificate
+	signerKey   *ecdsa.PrivateKey
+	mudContents []byte
+}
+
+// newFixtures generates a CA + signer + signed MUD file and writes
+// everything to a temp directory.
+func newFixtures(t *testing.T) *fixtures {
+	t.Helper()
+	dir := t.TempDir()
+	pinfo := ProductInfo{
+		Manufacturer: "Test Co",
+		CountryCode:  "US",
+		Model:        "TestModel",
+		MudUrl:       "https://example.com/test.json",
+		EmailAddress: "signer@example.com",
+		SerialNumber: "SN-1",
+	}
+
+	caBytes, caKey, err := GenCA(pinfo)
+	if err != nil {
+		t.Fatalf("GenCA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate(ca): %v", err)
+	}
+
+	signerBytes, signerKey, err := MakeSignerCert(pinfo, caCert, caKey)
+	if err != nil {
+		t.Fatalf("MakeSignerCert: %v", err)
+	}
+	signerCert, err := x509.ParseCertificate(signerBytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate(signer): %v", err)
+	}
+
+	mud := []byte(`{"ietf-mud:mud":{"mud-version":1,"mud-url":"https://example.com/test.json"}}`)
+	sig, err := SignMudFile(string(mud), signerCert, signerKey)
+	if err != nil {
+		t.Fatalf("SignMudFile: %v", err)
+	}
+
+	writeFile := func(name string, data []byte) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	caPath := writeFile("ca.pem", MakePEM(caBytes, "CERTIFICATE").Bytes())
+	signerPath := writeFile("signer.pem", MakePEM(signerBytes, "CERTIFICATE").Bytes())
+	sigPath := writeFile("mudfile.p7s", sig)
+	mudPath := writeFile("mud.json", mud)
+
+	return &fixtures{
+		dir:         dir,
+		caPath:      caPath,
+		signerPEM:   signerPath,
+		sigPath:     sigPath,
+		mudPath:     mudPath,
+		caCert:      caCert,
+		caKey:       caKey,
+		signerCert:  signerCert,
+		signerKey:   signerKey,
+		mudContents: mud,
+	}
+}
+
+// TestVerifyHappyPath confirms a freshly-generated CA + signer + signed
+// MUD file verifies successfully through the new code path.
+func TestVerifyHappyPath(t *testing.T) {
+	f := newFixtures(t)
+	if err := verify(f.caPath, "", f.sigPath, f.mudPath, time.Now()); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+// TestVerifyRejectsLeafAsRoot is the regression test for issue #21:
+// passing the signer leaf as the trust anchor must NOT verify
+// successfully, regardless of whether the signature is otherwise valid.
+func TestVerifyRejectsLeafAsRoot(t *testing.T) {
+	f := newFixtures(t)
+	err := verify(f.signerPEM, "", f.sigPath, f.mudPath, time.Now())
+	if err == nil {
+		t.Fatal("verify accepted signer leaf as trust anchor; want error")
+	}
+	// Must be rejected at the IsCA gate, not just by the verifier.
+	if want := "is not a CA"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v; want substring %q", err, want)
+	}
+}
+
+// TestVerifyRejectsWrongRoot confirms that a signature produced by a
+// different CA chain does not verify against an unrelated trust anchor.
+func TestVerifyRejectsWrongRoot(t *testing.T) {
+	good := newFixtures(t)
+	other := newFixtures(t) // independent CA
+
+	err := verify(other.caPath, "", good.sigPath, good.mudPath, time.Now())
+	if err == nil {
+		t.Fatal("verify accepted signature under unrelated CA; want error")
+	}
+}
+
+// TestVerifyRejectsTamperedMUD confirms that altering the signed payload
+// causes verification to fail.
+func TestVerifyRejectsTamperedMUD(t *testing.T) {
+	f := newFixtures(t)
+	tampered := append([]byte{}, f.mudContents...)
+	tampered[0] ^= 0xFF
+	tamperedPath := filepath.Join(f.dir, "mud-tampered.json")
+	if err := os.WriteFile(tamperedPath, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	if err := verify(f.caPath, "", f.sigPath, tamperedPath, time.Now()); err == nil {
+		t.Fatal("verify accepted tampered MUD file; want error")
+	}
+}
+
+// TestLoadPEMCertsErrors exercises the file-loading rules in isolation.
+func TestLoadPEMCertsErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("empty path", func(t *testing.T) {
+		if _, err := loadPEMCerts(""); err == nil {
+			t.Fatal("loadPEMCerts(\"\") returned nil error")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := loadPEMCerts(filepath.Join(dir, "nope.pem")); err == nil {
+			t.Fatal("loadPEMCerts(missing) returned nil error")
+		}
+	})
+
+	t.Run("no certificate blocks", func(t *testing.T) {
+		p := filepath.Join(dir, "empty.pem")
+		if err := os.WriteFile(p, []byte("not a PEM file"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadPEMCerts(p); err == nil {
+			t.Fatal("loadPEMCerts(no-certs) returned nil error")
+		}
+	})
+}


### PR DESCRIPTION
Addresses #21.

## Summary
The verifier previously dumped every PEM cert from `-cert` into `opts.Roots`. A user supplying a bundle that contained the signer leaf would make the leaf its own trust anchor — any CMS signature it produced would then verify successfully (CWE-295, same class as CVE-2020-26161).

This PR enforces a strict separation between trust anchors and intermediates, gates anchors on `IsCA`, and refactors `verify/verifymudsig.go` into testable pieces.

## Breaking change
The `-cert` flag is **removed**. Two new flags take its place:

| Flag | Required | Purpose |
|---|---|---|
| `-ca <file.pem>` | yes (default `ca.pem`) | One or more trust anchor certificates. Each must have `IsCA=true` or loading fails. |
| `-int <file.pem>` | no | Optional intermediate certs. Added to `opts.Intermediates`; never trusted as a root. |

The previous `-cert` semantics — "any cert in this file may be a root" — was the vulnerability and intentionally has no compatibility shim.

### Migration
```diff
-verifymudsig -cert signer-bundle.pem -sig mudfile.p7s mud.json
+verifymudsig -ca ca.pem -sig mudfile.p7s mud.json          # signer leaf reaches its CA directly
+verifymudsig -ca ca.pem -int intermediates.pem -sig mudfile.p7s mud.json   # multi-level chain
```

## Implementation
- `loadPEMCerts(path)` — reads a PEM file, returns every `CERTIFICATE` block parsed; non-CERTIFICATE blocks are skipped, zero certs is an error.
- `buildPools(caPath, intPath)` — loads both files, **rejects** any cert in `-ca` whose `IsCA` is false (this is the regression fix), populates `Roots` and `Intermediates` separately.
- `verify(caPath, intPath, sigPath, mudPath, now)` — extracted from `main` so tests can drive it without `os.Exec`.
- `main()` — thin flag wrapper.
- Errors are wrapped with `%w` so `errors.Is/As` works.
- Removed the dead duplicate `if err != nil { log.Fatal(err) }` block after `cms.ParseSignedData` (was a pre-existing copy-paste).

### Why `KeyUsages` is still `ExtKeyUsageAny`
The repo's `MakeSignerCert` does not currently set any Extended Key Usage on the signer certificate, and the CA carries `ClientAuth+ServerAuth` EKU. Requiring `ExtKeyUsageEmailProtection` here would break the tool's own happy path. A `NOTE` comment in the code records the intent to tighten this once `MakeSignerCert` is updated to set `EmailProtection`. Tracking that work is a follow-up (separate from #21).

## Tests
New `verify/verifymudsig_test.go` generates a fresh CA + signer + signed MUD file per test using the in-repo `mudcerts` library, all in `t.TempDir()`. Cases:

- `TestVerifyHappyPath` — clean CA + signer chain verifies.
- `TestVerifyRejectsLeafAsRoot` — **regression test for #21**: passing the signer leaf via `-ca` is rejected at the `IsCA` gate with a substring assertion on the error message.
- `TestVerifyRejectsWrongRoot` — signature under an independent CA fails verification against an unrelated anchor.
- `TestVerifyRejectsTamperedMUD` — flipping a byte in the signed payload causes verification to fail.
- `TestLoadPEMCertsErrors` — empty path, missing file, no `CERTIFICATE` blocks all error.

## Verification
```
$ go vet ./...
$ go test -race ./...
ok    github.com/iot-onboarding/mudcerts        1.715s
ok    github.com/iot-onboarding/mudcerts/verify 1.356s
ok    github.com/iot-onboarding/mudcerts/web    2.005s
```
