### PR TITLE
cleanup: wrap errors with %w, check pem.Encode return (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import (
 
 [func GenCA(ProductInfo) ([]byte, *ecdsa.PrivateKey, error)](#func-genca)\
 [func MakeMUDcert(ProductInfo, *x509.Certificate, *ecdsa.PrivateKey) ([]byte,*ecdsa.PrivateKey,error)](#func-makemudcert)\
-[func MakePEM([]byte, string) *bytes.Buffer](#func-makepem)\
+[func MakePEM([]byte, string) (*bytes.Buffer, error)](#func-makepem)\
 [func MakeSignerCert(p ProductInfo, ca *x509.Certificate, caPrivKey *ecdsa.PrivateKey) ([]byte, *ecdsa.PrivateKey, error)](#func-makesignercert)\
 [func SignMudFile(mudfile string, signerCert *x509.Certificate,
         certkey *ecdsa.PrivateKey) ([]byte, error)](#func-signmudfile) \
@@ -54,9 +54,9 @@ Returns a cert in the byte array, its associate private key, or an error.
 Returns a product cert with appropriate MUD extensions, an associated private key, or an error.  Requires the output from GenCA.
 
 ### func MakePEM
-> func MakePEM([]byte, string) *bytes.Buffer
+> func MakePEM([]byte, string) (*bytes.Buffer, error)
 
-Generates a PEM file with the header passed as a second argument.
+Generates a PEM file with the header passed as a second argument. Returns an error if PEM encoding fails.
 
 ### func MakeSignerCert
 > MakeSignerCert(p ProductInfo, ca *x509.Certificate, caPrivKey *ecdsa.PrivateKey) ([]byte, *ecdsa.PrivateKey, error)

--- a/cli/mkmudcerts.go
+++ b/cli/mkmudcerts.go
@@ -78,7 +78,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	capem := MakePEM(cabytes, "CERTIFICATE")
+	capem, err := MakePEM(cabytes, "CERTIFICATE")
+	if err != nil {
+		log.Fatal(err)
+	}
 	mudcert, mudcertPrivKey, err := MakeMUDcert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		log.Fatal(err)
@@ -88,14 +91,38 @@ func main() {
 		log.Fatal(err)
 	}
 
-	mudcertpem := MakePEM(mudcert, "CERTIFICATE")
-	caPrivBytes, _ := x509.MarshalECPrivateKey(caPrivKey)
-	caPrivkeyPEM := MakePEM(caPrivBytes, "PRIVATE KEY")
-	mudPrivBytes, _ := x509.MarshalECPrivateKey(mudcertPrivKey)
-	mudPrivKeyPEM := MakePEM(mudPrivBytes, "PRIVATE KEY")
-	mudsignerPEM := MakePEM(mudsigner, "CERTIFICATE")
-	mudsignerPrivBytes, _ := x509.MarshalECPrivateKey(mudsignerPrivKey)
-	mudsignerPrivKeyPEM := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	mudcertpem, err := MakePEM(mudcert, "CERTIFICATE")
+	if err != nil {
+		log.Fatal(err)
+	}
+	caPrivBytes, err := x509.MarshalECPrivateKey(caPrivKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	caPrivkeyPEM, err := MakePEM(caPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		log.Fatal(err)
+	}
+	mudPrivBytes, err := x509.MarshalECPrivateKey(mudcertPrivKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	mudPrivKeyPEM, err := MakePEM(mudPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		log.Fatal(err)
+	}
+	mudsignerPEM, err := MakePEM(mudsigner, "CERTIFICATE")
+	if err != nil {
+		log.Fatal(err)
+	}
+	mudsignerPrivBytes, err := x509.MarshalECPrivateKey(mudsignerPrivKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	mudsignerPrivKeyPEM, err := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Println(capem)
 	fmt.Println(caPrivkeyPEM)

--- a/genca.go
+++ b/genca.go
@@ -60,11 +60,11 @@ func GenCA(p ProductInfo) ([]byte, *ecdsa.PrivateKey, error) {
 
 	caPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate CA key: %w", err)
 	}
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create CA certificate: %w", err)
 	}
 
 	return caBytes, caPrivKey, nil

--- a/mkpem.go
+++ b/mkpem.go
@@ -21,14 +21,20 @@ package mudcerts
 import (
 	"bytes"
 	"encoding/pem"
+	"fmt"
 )
 
-// MakePEM returns a PEM string in a Buffer.
-func MakePEM(inBytes []byte, pemtype string) *bytes.Buffer {
+// MakePEM returns a PEM-encoded buffer for the given DER bytes and
+// block type. It returns an error if pem.Encode fails (which in
+// practice only happens on a programmer error such as a bad block
+// header), so callers should still check err.
+func MakePEM(inBytes []byte, pemtype string) (*bytes.Buffer, error) {
 	outPEM := new(bytes.Buffer)
-	pem.Encode(outPEM, &pem.Block{
+	if err := pem.Encode(outPEM, &pem.Block{
 		Type:  pemtype,
 		Bytes: inBytes,
-	})
-	return outPEM
+	}); err != nil {
+		return nil, fmt.Errorf("pem encode %s: %w", pemtype, err)
+	}
+	return outPEM, nil
 }

--- a/mudcert.go
+++ b/mudcert.go
@@ -38,7 +38,7 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 
 	urlentry, err := asn1.Marshal(p.MudUrl)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("marshal MUD URL extension: %w", err)
 	}
 	mudurlExtension := pkix.Extension{
 		Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 25},
@@ -54,7 +54,7 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 	mudSignerSeq, err := asn1.Marshal(signerName.ToRDNSequence())
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("marshal MUD signer extension: %w", err)
 	}
 
 	mudSignerExt := pkix.Extension{
@@ -63,11 +63,11 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 	}
 	ski, err := certSKI()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate subject key identifier: %w", err)
 	}
 	serNum, err := certSerial()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate certificate serial: %w", err)
 	}
 
 	cert := &x509.Certificate{
@@ -88,12 +88,12 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 
 	certPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate MUD key: %w", err)
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create MUD certificate: %w", err)
 	}
 	return certBytes, certPrivKey, nil
 }

--- a/serials.go
+++ b/serials.go
@@ -28,7 +28,7 @@ import (
 func certSerial() (*big.Int, error) {
 	serNum, err := rand.Int(rand.Reader, big.NewInt(9223372036854))
 	if err != nil {
-		return big.NewInt(0), fmt.Errorf("%s", err)
+		return big.NewInt(0), fmt.Errorf("read random for serial: %w", err)
 	}
 	return serNum, nil
 }
@@ -37,7 +37,7 @@ func certSerial() (*big.Int, error) {
 func certSKI() ([]byte, error) {
 	ski, err := rand.Int(rand.Reader, big.NewInt(9223372036854775807))
 	if err != nil {
-		return nil, fmt.Errorf("%s", err)
+		return nil, fmt.Errorf("read random for SKI: %w", err)
 	}
 	return ski.Bytes(), nil
 }

--- a/signercert.go
+++ b/signercert.go
@@ -36,12 +36,12 @@ func MakeSignerCert(p ProductInfo,
 
 	serNum, err := certSerial()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate certificate serial: %w", err)
 	}
 
 	ski, err := certSKI()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate subject key identifier: %w", err)
 	}
 
 	cert := &x509.Certificate{
@@ -61,12 +61,12 @@ func MakeSignerCert(p ProductInfo,
 
 	certPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate signer key: %w", err)
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create signer certificate: %w", err)
 	}
 	return certBytes, certPrivKey, nil
 }

--- a/smimesign.go
+++ b/smimesign.go
@@ -32,7 +32,7 @@ func SignMudFile(mudfile string, signerCert *x509.Certificate,
 	certChain := []*x509.Certificate{signerCert}
 	signature, err := cms.SignDetached([]byte(mudfile), certChain, certkey)
 	if err != nil {
-		return nil, fmt.Errorf("%s", err)
+		return nil, fmt.Errorf("sign MUD file: %w", err)
 	}
 	return signature, nil
 }

--- a/verify/verifymudsig.go
+++ b/verify/verifymudsig.go
@@ -92,9 +92,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err != nil {
-		log.Fatal(err)
-	}
 	if _, err := sd.VerifyDetached(mudfile, opts); err != nil {
 		log.Fatal(err)
 	}

--- a/web/mudzipserver.go
+++ b/web/mudzipserver.go
@@ -222,7 +222,11 @@ func postMUD(c *gin.Context) {
 		return
 	}
 
-	capem := MakePEM(cabytes, "CERTIFICATE")
+	capem, err := MakePEM(cabytes, "CERTIFICATE")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode CA PEM", err)
+		return
+	}
 	mudcert, mudcertPrivKey, err := MakeMUDcert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to create MUD certificate", err)
@@ -235,26 +239,46 @@ func postMUD(c *gin.Context) {
 		return
 	}
 
-	mudcertpem := MakePEM(mudcert, "CERTIFICATE")
-	mudsignerpem := MakePEM(mudsigner, "CERTIFICATE")
+	mudcertpem, err := MakePEM(mudcert, "CERTIFICATE")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode MUD cert PEM", err)
+		return
+	}
+	mudsignerpem, err := MakePEM(mudsigner, "CERTIFICATE")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode MUD signer PEM", err)
+		return
+	}
 	caPrivBytes, err := x509.MarshalECPrivateKey(caPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal CA private key", err)
 		return
 	}
-	caPrivkeyPEM := MakePEM(caPrivBytes, "PRIVATE KEY")
+	caPrivkeyPEM, err := MakePEM(caPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode CA key PEM", err)
+		return
+	}
 	mudPrivBytes, err := x509.MarshalECPrivateKey(mudcertPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal MUD private key", err)
 		return
 	}
-	mudPrivKeyPEM := MakePEM(mudPrivBytes, "PRIVATE KEY")
+	mudPrivKeyPEM, err := MakePEM(mudPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode MUD key PEM", err)
+		return
+	}
 	mudsignerPrivBytes, err := x509.MarshalECPrivateKey(mudsignerPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal MUD signer private key", err)
 		return
 	}
-	mudsignerPrivKeyPEM := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	mudsignerPrivKeyPEM, err := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	if err != nil {
+		httpError(c, http.StatusInternalServerError, "failed to encode MUD signer key PEM", err)
+		return
+	}
 
 	mudsigncert, err := x509.ParseCertificate(mudsigner)
 	if err != nil {


### PR DESCRIPTION
Addresses #27.

Mechanical code-quality pass; no behavior change other than `MakePEM`'s new error return.

## Changes

### `mkpem.go` — check `pem.Encode` return
`MakePEM` now returns `(*bytes.Buffer, error)` and propagates any `pem.Encode` failure with `%w` wrapping. Callers in `cli/mkmudcerts.go` and `web/mudzipserver.go` updated; `README.md` signature updated. While `pem.Encode` writing to a `bytes.Buffer` cannot realistically fail today, the new signature satisfies the "don't ignore errors" rule and future-proofs the API against changes in `encoding/pem`.

### `verify/verifymudsig.go` — drop duplicate `log.Fatal` block
Removed the dead `if err != nil { log.Fatal(err) }` immediately after `cms.ParseSignedData`. The same fix is part of PR #33 (issue #21), but this PR resolves it against current `main` so the cleanup lands regardless of merge order. The two PRs will conflict in this file — whichever merges first wins, and the other resolves trivially.

### Library packages — replace `fmt.Errorf("%s", err)` with `fmt.Errorf("<context>: %w", err)`
15 sites across 5 files, with verb-phrase contexts describing the failed operation:

| File | Context |
|---|---|
| `genca.go` | `generate CA key`, `create CA certificate` |
| `mudcert.go` | `marshal MUD URL extension`, `marshal MUD signer extension`, `generate subject key identifier`, `generate certificate serial`, `generate MUD key`, `create MUD certificate` |
| `signercert.go` | `generate certificate serial`, `generate subject key identifier`, `generate signer key`, `create signer certificate` |
| `smimesign.go` | `sign MUD file` |
| `serials.go` | `read random for serial`, `read random for SKI` |

Callers can now use `errors.Is` / `errors.As` against the underlying error (e.g. `crypto/rand` failures).

## Verification

```
$ go vet ./...
$ go build ./...
$ go test -race ./...
ok   github.com/iot-onboarding/mudcerts        1.628s
ok   github.com/iot-onboarding/mudcerts/web    1.898s
```
