### PR TITLE
cleanup: wrap errors with %w, check pem.Encode return (closes #27)

### DIFF
--- a/genca.go
+++ b/genca.go
@@ -60,11 +60,11 @@ func GenCA(p ProductInfo) ([]byte, *ecdsa.PrivateKey, error) {
 
 	caPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate CA key: %w", err)
 	}
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create CA certificate: %w", err)
 	}
 
 	return caBytes, caPrivKey, nil

--- a/mkpem.go
+++ b/mkpem.go
@@ -21,14 +21,20 @@ package mudcerts
 import (
 	"bytes"
 	"encoding/pem"
+	"fmt"
 )
 
-// MakePEM returns a PEM string in a Buffer.
+// MakePEM returns a PEM string in a Buffer. pem.Encode can only fail
+// if the underlying io.Writer returns an error; since bytes.Buffer.Write
+// never does, a non-nil error here would indicate a programmer error
+// (e.g. a malformed pem.Block header) and is treated as unrecoverable.
 func MakePEM(inBytes []byte, pemtype string) *bytes.Buffer {
 	outPEM := new(bytes.Buffer)
-	pem.Encode(outPEM, &pem.Block{
+	if err := pem.Encode(outPEM, &pem.Block{
 		Type:  pemtype,
 		Bytes: inBytes,
-	})
+	}); err != nil {
+		panic(fmt.Errorf("mudcerts: pem.Encode %s: %w", pemtype, err))
+	}
 	return outPEM
 }

--- a/mudcert.go
+++ b/mudcert.go
@@ -38,7 +38,7 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 
 	urlentry, err := asn1.Marshal(p.MudUrl)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("marshal MUD URL extension: %w", err)
 	}
 	mudurlExtension := pkix.Extension{
 		Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 25},
@@ -54,7 +54,7 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 	mudSignerSeq, err := asn1.Marshal(signerName.ToRDNSequence())
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("marshal MUD signer extension: %w", err)
 	}
 
 	mudSignerExt := pkix.Extension{
@@ -63,11 +63,11 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 	}
 	ski, err := certSKI()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate subject key identifier: %w", err)
 	}
 	serNum, err := certSerial()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate certificate serial: %w", err)
 	}
 
 	cert := &x509.Certificate{
@@ -88,12 +88,12 @@ func MakeMUDcert(p ProductInfo, ca *x509.Certificate,
 
 	certPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate MUD key: %w", err)
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create MUD certificate: %w", err)
 	}
 	return certBytes, certPrivKey, nil
 }

--- a/serials.go
+++ b/serials.go
@@ -28,7 +28,7 @@ import (
 func certSerial() (*big.Int, error) {
 	serNum, err := rand.Int(rand.Reader, big.NewInt(9223372036854))
 	if err != nil {
-		return big.NewInt(0), fmt.Errorf("%s", err)
+		return big.NewInt(0), fmt.Errorf("read random for serial: %w", err)
 	}
 	return serNum, nil
 }
@@ -37,7 +37,7 @@ func certSerial() (*big.Int, error) {
 func certSKI() ([]byte, error) {
 	ski, err := rand.Int(rand.Reader, big.NewInt(9223372036854775807))
 	if err != nil {
-		return nil, fmt.Errorf("%s", err)
+		return nil, fmt.Errorf("read random for SKI: %w", err)
 	}
 	return ski.Bytes(), nil
 }

--- a/signercert.go
+++ b/signercert.go
@@ -36,12 +36,12 @@ func MakeSignerCert(p ProductInfo,
 
 	serNum, err := certSerial()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate certificate serial: %w", err)
 	}
 
 	ski, err := certSKI()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate subject key identifier: %w", err)
 	}
 
 	cert := &x509.Certificate{
@@ -61,12 +61,12 @@ func MakeSignerCert(p ProductInfo,
 
 	certPrivKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("generate signer key: %w", err)
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%s", err)
+		return nil, nil, fmt.Errorf("create signer certificate: %w", err)
 	}
 	return certBytes, certPrivKey, nil
 }

--- a/smimesign.go
+++ b/smimesign.go
@@ -32,7 +32,7 @@ func SignMudFile(mudfile string, signerCert *x509.Certificate,
 	certChain := []*x509.Certificate{signerCert}
 	signature, err := cms.SignDetached([]byte(mudfile), certChain, certkey)
 	if err != nil {
-		return nil, fmt.Errorf("%s", err)
+		return nil, fmt.Errorf("sign MUD file: %w", err)
 	}
 	return signature, nil
 }


### PR DESCRIPTION
Addresses #27. Mechanical code-quality pass; no behavior change.

## Changes

### `mkpem.go` — check `pem.Encode` return
`MakePEM` now inspects the `pem.Encode` return. Because `bytes.Buffer.Write` never returns an error, a non-nil result here would indicate a programmer error (e.g. a malformed `pem.Block` header), so it `panic`s with a `%w`-wrapped message. The exported signature is unchanged — no callers need updating.

### Library packages — replace `fmt.Errorf("%s", err)` with `fmt.Errorf("<context>: %w", err)`
15 sites across 5 files, with verb-phrase contexts describing the failed operation:

| File | Contexts |
|---|---|
| `genca.go` | `generate CA key`, `create CA certificate` |
| `mudcert.go` | `marshal MUD URL extension`, `marshal MUD signer extension`, `generate subject key identifier`, `generate certificate serial`, `generate MUD key`, `create MUD certificate` |
| `signercert.go` | `generate certificate serial`, `generate subject key identifier`, `generate signer key`, `create signer certificate` |
| `smimesign.go` | `sign MUD file` |
| `serials.go` | `read random for serial`, `read random for SKI` |

Callers can now use `errors.Is` / `errors.As` against the underlying error (e.g. `crypto/rand` failures).

### `verify/verifymudsig.go` — duplicate `log.Fatal` block
Already removed when PR #33 (issue #21) rewrote that file; no change required here.

## Verification

```
$ go vet ./...
$ go build ./...
$ go test -race ./...
ok   github.com/iot-onboarding/mudcerts        (cached)
ok   github.com/iot-onboarding/mudcerts/verify 1.665s
ok   github.com/iot-onboarding/mudcerts/web    2.001s
```
