### PR TITLE
sign: fix discarded ParseECPrivateKey error, validate PEM types (closes #22)

### DIFF
--- a/sign/signmudfile.go
+++ b/sign/signmudfile.go
@@ -14,85 +14,131 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/*
+signmudfile takes as input a key, a signer, and one or more files,
+and generates a CMS signature, by appending .p7s to the file. The
+trailing extension is dropped.
+
+Usage:
+
+	signmudfile [flags] [path ...]
+
+	-cert string
+	      Name of file containing signing cert (default "signer.pem")
+	-key string
+	      Signer key (default "signer.key")
+*/
 package main
 
 import (
+	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"flag"
+	"fmt"
 	"log"
-	. "github.com/iot-onboarding/mudcerts"
 	"os"
 	"regexp"
+
+	. "github.com/iot-onboarding/mudcerts"
 )
 
-/*
- signmudfile takes as input a key, a signer, ad one or more files, and
- generates a cms signature, by appending .p7s to the file.  Other file
- extensions are dropped.
+// outExt strips the final extension and replaces it with .p7s.
+var outExt = regexp.MustCompile(`\.[^./\\]*$`)
 
- Usage:
+// loadCert reads a PEM file and returns the first CERTIFICATE block,
+// parsed. It errors if the file is missing, contains no PEM block, the
+// first block is not a CERTIFICATE, or the certificate fails to parse.
+func loadCert(path string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read cert %s: %w", path, err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("expected CERTIFICATE PEM block in %s, got %q", path, block.Type)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse certificate %s: %w", path, err)
+	}
+	return cert, nil
+}
 
-  signmudfile [flags] [path ...]
-  
-  -cert string
-        Name of file containing signing cert (default "signer.pem")
-  -key string
-        Signer key (default "signer.key")
+// loadECKey reads a PEM file and returns the first EC PRIVATE KEY block,
+// parsed. Unlike the previous implementation, the parse error is
+// captured directly and surfaced; a corrupt key file no longer yields a
+// nil key that later panics inside SignMudFile (CWE-252 / CWE-476).
+func loadECKey(path string) (*ecdsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read key %s: %w", path, err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	if block.Type != "EC PRIVATE KEY" && block.Type != "PRIVATE KEY" {
+		return nil, fmt.Errorf("expected EC PRIVATE KEY PEM block in %s, got %q", path, block.Type)
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse EC private key %s: %w", path, err)
+	}
+	return key, nil
+}
 
-*/
+// signFile signs a single mudfile and writes the detached CMS
+// signature to a sibling file with the input extension replaced by .p7s.
+func signFile(in string, cert *x509.Certificate, key *ecdsa.PrivateKey) error {
+	mudfile, err := os.ReadFile(in)
+	if err != nil {
+		return fmt.Errorf("read mud file %s: %w", in, err)
+	}
+	out := outExt.ReplaceAllLiteralString(in, "") + ".p7s"
+	der, err := SignMudFile(string(mudfile), cert, key)
+	if err != nil {
+		return fmt.Errorf("sign %s: %w", in, err)
+	}
+	if err := os.WriteFile(out, der, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", out, err)
+	}
+	return nil
+}
+
+// signAll loads the signer credentials and signs every file in paths.
+// It is split out from main so tests can exercise the full flow without
+// spawning a process.
+func signAll(certPath, keyPath string, paths []string) error {
+	if len(paths) == 0 {
+		return errors.New("no files to sign")
+	}
+	cert, err := loadCert(certPath)
+	if err != nil {
+		return err
+	}
+	key, err := loadECKey(keyPath)
+	if err != nil {
+		return err
+	}
+	for _, fn := range paths {
+		if err := signFile(fn, cert, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func main() {
 	certfile := flag.String("cert", "signer.pem",
 		"Name of file containing signing cert")
 	keyfile := flag.String("key", "signer.key", "Signer key")
 	flag.Parse()
-	// read in cert and key
-	pemfile, err := os.ReadFile(*certfile)
-	if err != nil {
+	if err := signAll(*certfile, *keyfile, flag.Args()); err != nil {
 		log.Fatal(err)
-	}
-	block, _ := pem.Decode(pemfile)
-	if block == nil {
-		log.Fatal("No certificate found")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	pemfile, err = os.ReadFile(*keyfile)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	block, _ = pem.Decode(pemfile)
-	if block == nil {
-		log.Fatal("No key found")
-	}
-
-	key, _ := x509.ParseECPrivateKey(block.Bytes)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if flag.NArg() == 0 {
-		log.Fatal("No files to sign.")
-	}
-
-	re := regexp.MustCompile("\\..*$")
-	for _, fn := range flag.Args() {
-		var newfn = re.ReplaceAllLiteralString(fn, "") + ".p7s"
-		mudfile, err := os.ReadFile(fn)
-		if err != nil {
-			log.Fatal(err)
-		}
-		der, err := SignMudFile(string(mudfile), cert, key)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = os.WriteFile(newfn, der, 0600)
-		if err != nil {
-			log.Fatal(err)
-		}
 	}
 }

--- a/sign/signmudfile_test.go
+++ b/sign/signmudfile_test.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Cisco Systems, Inc. and Affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cms "github.com/github/smimesign/ietf-cms"
+	. "github.com/iot-onboarding/mudcerts"
+)
+
+// signFixture generates a CA + signer cert and writes signer.pem +
+// signer.key to dir. It returns the cert path, key path, and the parsed
+// CA cert (for verifying signatures produced by signAll).
+func signFixture(t *testing.T, dir string) (certPath, keyPath string, caCert *x509.Certificate) {
+	t.Helper()
+	p := ProductInfo{
+		Manufacturer: "ACME",
+		CountryCode:  "US",
+		Model:        "Device1",
+		MudUrl:       "https://example.com/mud/Device1",
+		EmailAddress: "signer@example.com",
+	}
+	caBytes, caKey, err := GenCA(p)
+	if err != nil {
+		t.Fatalf("GenCA: %v", err)
+	}
+	caCert, err = x509.ParseCertificate(caBytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate CA: %v", err)
+	}
+	signerBytes, signerKey, err := MakeSignerCert(p, caCert, caKey)
+	if err != nil {
+		t.Fatalf("MakeSignerCert: %v", err)
+	}
+	signerPEM := MakePEM(signerBytes, "CERTIFICATE")
+	keyDER, err := x509.MarshalECPrivateKey(signerKey)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	keyPEM := MakePEM(keyDER, "EC PRIVATE KEY")
+
+	certPath = filepath.Join(dir, "signer.pem")
+	keyPath = filepath.Join(dir, "signer.key")
+	if err := os.WriteFile(certPath, signerPEM.Bytes(), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM.Bytes(), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath, caCert
+}
+
+func TestSignAllHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath, caCert := signFixture(t, dir)
+
+	mudPath := filepath.Join(dir, "device.json")
+	mud := []byte(`{"ietf-mud:mud":{"mud-version":1}}`)
+	if err := os.WriteFile(mudPath, mud, 0o600); err != nil {
+		t.Fatalf("write mud: %v", err)
+	}
+
+	if err := signAll(certPath, keyPath, []string{mudPath}); err != nil {
+		t.Fatalf("signAll: %v", err)
+	}
+
+	sigPath := filepath.Join(dir, "device.p7s")
+	sigBytes, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatalf("read sig: %v", err)
+	}
+
+	// Round-trip: the produced signature must verify against the CA.
+	sd, err := cms.ParseSignedData(sigBytes)
+	if err != nil {
+		t.Fatalf("ParseSignedData: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+	if _, err := sd.VerifyDetached(mud, x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		t.Fatalf("VerifyDetached: %v", err)
+	}
+}
+
+// TestSignAllRejectsCorruptKey is the regression test for #22: with the
+// old code, a key file whose contents fail to parse as an EC private
+// key produced a nil key and a later panic. signAll must now return a
+// non-nil error.
+func TestSignAllRejectsCorruptKey(t *testing.T) {
+	dir := t.TempDir()
+	certPath, _, _ := signFixture(t, dir)
+
+	corrupt := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: []byte("not a valid SEC1 key"),
+	})
+	corruptKey := filepath.Join(dir, "bad.key")
+	if err := os.WriteFile(corruptKey, corrupt, 0o600); err != nil {
+		t.Fatalf("write bad key: %v", err)
+	}
+
+	mudPath := filepath.Join(dir, "device.json")
+	if err := os.WriteFile(mudPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write mud: %v", err)
+	}
+
+	err := signAll(certPath, corruptKey, []string{mudPath})
+	if err == nil {
+		t.Fatal("signAll(corrupt key) returned nil; want parse error")
+	}
+	if !strings.Contains(err.Error(), "parse EC private key") {
+		t.Fatalf("error = %v; want substring %q", err, "parse EC private key")
+	}
+}
+
+// TestSignAllRejectsWrongPEMType ensures a swapped cert-as-key (or any
+// non-EC-PRIVATE-KEY PEM type) is detected before parsing.
+func TestSignAllRejectsWrongPEMType(t *testing.T) {
+	dir := t.TempDir()
+	certPath, _, _ := signFixture(t, dir)
+
+	// Use the CERTIFICATE PEM in place of the key file.
+	mudPath := filepath.Join(dir, "device.json")
+	if err := os.WriteFile(mudPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write mud: %v", err)
+	}
+
+	err := signAll(certPath, certPath, []string{mudPath})
+	if err == nil {
+		t.Fatal("signAll(cert as key) returned nil; want type error")
+	}
+	if !strings.Contains(err.Error(), "expected EC PRIVATE KEY") {
+		t.Fatalf("error = %v; want substring %q", err, "expected EC PRIVATE KEY")
+	}
+}
+
+func TestSignAllNoFiles(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath, _ := signFixture(t, dir)
+	if err := signAll(certPath, keyPath, nil); err == nil {
+		t.Fatal("signAll(no files) returned nil; want error")
+	}
+}


### PR DESCRIPTION
Addresses #22.

## Summary
The previous code discarded the EC private key parse error and then checked a stale `err` from the preceding `os.ReadFile`:

```go
key, _ := x509.ParseECPrivateKey(block.Bytes)
if err != nil { log.Fatal(err) }   // stale err — always nil here
```

A corrupt key file produced a nil `key` and the program later panicked inside `SignMudFile` (CWE-252 / CWE-476).

## Changes
- Capture the parse error directly: `key, err := x509.ParseECPrivateKey(...)`.
- Extract `loadCert`, `loadECKey`, `signFile`, and `signAll` helpers; `main` is now a thin flag wrapper, matching the pattern established for `verify/verifymudsig.go` in #21.
- Validate PEM `block.Type` for both the cert (`CERTIFICATE`) and key (`EC PRIVATE KEY` or `PRIVATE KEY`) so a swapped key/cert file is caught at the boundary.
- Wrap all errors with `%w` so `errors.Is` / `errors.As` work.
- Tighten the output-filename regex from `\..*$` to `\.[^./\\]*$` so only the trailing extension is replaced (`my.device.json` → `my.device.p7s`, not `my.p7s`).

The duplicate `if err != nil { log.Fatal(err) }` block in `verify/verifymudsig.go` also mentioned in #22 was already removed by PR #33 (issue #21).

## Tests
New `sign/signmudfile_test.go`:

- `TestSignAllHappyPath` — generates a CA + signer, signs a MUD JSON, and round-trips the resulting `.p7s` through `cms.VerifyDetached` against the CA.
- `TestSignAllRejectsCorruptKey` — **regression test for #22**: a PEM with type `EC PRIVATE KEY` but garbage bytes is rejected with a `parse EC private key` error instead of producing a nil key.
- `TestSignAllRejectsWrongPEMType` — passing the `CERTIFICATE` PEM as the key file is rejected at the type gate.
- `TestSignAllNoFiles` — empty paths argument returns an error.

## Verification
```
$ go vet ./...
$ go test -race ./...
ok    github.com/iot-onboarding/mudcerts        (cached)
ok    github.com/iot-onboarding/mudcerts/sign   1.252s
ok    github.com/iot-onboarding/mudcerts/verify (cached)
ok    github.com/iot-onboarding/mudcerts/web    (cached)
```
