### PR TITLE
web: include -binary in README's openssl cms verify example

### DIFF
--- a/web/mudzipserver.go
+++ b/web/mudzipserver.go
@@ -159,10 +159,12 @@ YOURDEVICE.p7s    --> A detached CMS signature of your MUD file
                       signed with mudsigner.pem.
 
 You can verifiy the signature of the MUD file with the following openssl
-command:
+command. The -binary flag is required: the MUD file is signed verbatim
+(as binary CMS data), and without -binary openssl performs SMIME-style
+CRLF canonicalization on the content and the digest no longer matches.
 
  % openssl cms -verify -in YOURDEVICE.p7s -inform DER -content YOURDEVICE.json \
-    -CAfile ca.pem -purpose any -out /dev/null
+    -CAfile ca.pem -purpose any -binary -out /dev/null
 
 The source code used to build the zip file can be found at the following location:
 https://github.com/iot-onboarding/mudcerts

--- a/web/mudzipserver_test.go
+++ b/web/mudzipserver_test.go
@@ -132,6 +132,49 @@ func TestPostMUDProducesZip(t *testing.T) {
 	}
 }
 
+// TestREADMEOpensslVerifyHasBinary guards against a regression where the
+// openssl verification snippet in README.txt is missing the -binary flag.
+// Without -binary, openssl applies SMIME-style CRLF canonicalization to
+// the content and the digest no longer matches the messageDigest signed
+// attribute that smimesign/ietf-cms produced over the verbatim bytes,
+// so end users following the README see a spurious verification failure.
+func TestREADMEOpensslVerifyHasBinary(t *testing.T) {
+	w := postPInfo(t, validPInfo())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q; want 200", w.Code, w.Body.String())
+	}
+	zr, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	var readme []byte
+	for _, f := range zr.File {
+		if f.Name != "README.txt" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open README.txt: %v", err)
+		}
+		readme, err = io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read README.txt: %v", err)
+		}
+		break
+	}
+	if len(readme) == 0 {
+		t.Fatal("README.txt entry not found in zip")
+	}
+	// Find the openssl cms -verify command and confirm it carries -binary.
+	if !bytes.Contains(readme, []byte("openssl cms -verify")) {
+		t.Fatal("README.txt missing 'openssl cms -verify' snippet")
+	}
+	if !bytes.Contains(readme, []byte("-binary")) {
+		t.Errorf("README.txt openssl example missing -binary flag; got:\n%s", readme)
+	}
+}
+
 // TestPostMUDBodyTooLarge verifies that requests exceeding the body-size
 // limit are rejected with 413 and that the handler does not perform any
 // expensive crypto work.


### PR DESCRIPTION
## Summary

The README embedded in the signed MUD zip tells users to verify the
detached CMS signature with:

```
openssl cms -verify -in YOURDEVICE.p7s -inform DER -content YOURDEVICE.json \
    -CAfile ca.pem -purpose any -out /dev/null
```

That command fails for every zip the server produces:

```
Verification failure
80E16E5D01000000:error:1100007B:CMS routines:CMS_SignerInfo_verify_content:verification failure
```

even though the signature is cryptographically valid and `verifymudsig`
(in this repo) reports `Ok.` on the same files.

## Root cause

`smimesign.SignMudFile` calls `cms.SignDetached([]byte(mudfile), ...)`,
signing the MUD JSON bytes verbatim. Without `-binary`, `openssl
cms -verify` applies SMIME-style CRLF canonicalization to the bytes
passed via `-content`, so the SHA-256 it computes no longer matches the
`messageDigest` signed attribute in the CMS structure and verification
fails.

Reproduction on a real zip (`Controls lighting.zip`):

- `shasum -a 256 Controls_lighting.json` =
  `5f5ea800cb5b69a0ccdaa849098a0dfa8150e8b40b10fd8474176cc639c6f748`
- `openssl cms -cmsout -print -in Controls_lighting.p7s -inform DER -noout`
  shows the same value as the signed `messageDigest` attribute.
- `openssl cms -verify ... -binary -out /dev/null` succeeds.
- `openssl cms -verify ... -out /dev/null` (no `-binary`) fails.

## Fix

Add `-binary` to the `openssl cms -verify` invocation in the README
template, plus a short explanatory paragraph so users understand why
the flag is required.

## Test

New `TestREADMEOpensslVerifyHasBinary` posts a valid `ProductInfo`,
opens `README.txt` from the response zip, and asserts the openssl
example contains both `openssl cms -verify` and `-binary`. This guards
against regressing the snippet back to the broken form.

`go test -race ./web/` passes.

Also manually verified end-to-end: after `unzip` the generated bundle,
the README's command (copy-pasted) returns `CMS Verification successful`.
