### PR TITLE
web: cap concurrent /mudzip requests with bounded semaphore (closes #23)

### DIFF
--- a/web/mudzipserver.go
+++ b/web/mudzipserver.go
@@ -42,7 +42,9 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/iot-onboarding/mudcerts"
@@ -52,6 +54,44 @@ import (
 // plus the surrounding ProductInfo JSON should comfortably fit; anything
 // larger is treated as abuse.
 const maxRequestBytes = 150 * 1024 // 150 KiB
+
+// acquireTimeout bounds how long a request will wait for a concurrency
+// slot before the server gives up and returns 429. Kept short so that
+// clients fail fast under sustained load rather than queueing forever
+// and exhausting server-side resources (sockets, goroutines, memory).
+const acquireTimeout = 100 * time.Millisecond
+
+// concurrencyLimiter returns a gin middleware that admits at most
+// `capacity` concurrent requests through the protected handler chain.
+// Excess requests wait up to `timeout` for a slot to free; if none is
+// available they are rejected with HTTP 429 and a Retry-After header.
+//
+// Each /mudzip request performs three ECDSA key generations plus a CMS
+// sign, all CPU-bound. Without a cap, a handful of concurrent callers
+// can saturate the host (CWE-770). The semaphore here caps in-flight
+// crypto work to a value proportional to available CPUs. Operators are
+// still expected to run this service behind a reverse proxy that
+// enforces per-IP rate limits.
+func concurrencyLimiter(capacity int, timeout time.Duration) gin.HandlerFunc {
+	if capacity < 1 {
+		capacity = 1
+	}
+	sem := make(chan struct{}, capacity)
+	return func(c *gin.Context) {
+		select {
+		case sem <- struct{}{}:
+			defer func() { <-sem }()
+			c.Next()
+		case <-time.After(timeout):
+			c.Header("Retry-After", "1")
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": "server busy, try again later",
+			})
+		case <-c.Request.Context().Done():
+			c.AbortWithStatus(499) // client closed request
+		}
+	}
+}
 
 // limitBody installs an http.MaxBytesReader on every incoming request so
 // that BindJSON (and any other body reader) cannot exhaust memory.
@@ -341,6 +381,7 @@ func main() {
 	router := gin.Default()
 	router.SetTrustedProxies(nil)
 	router.Use(limitBody(maxRequestBytes))
+	router.Use(concurrencyLimiter(runtime.NumCPU(), acquireTimeout))
 	router.POST("/mudzip", postMUD)
 	router.Run(":8085")
 }

--- a/web/mudzipserver_test.go
+++ b/web/mudzipserver_test.go
@@ -20,7 +20,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/iot-onboarding/mudcerts"
@@ -309,6 +311,79 @@ func TestModelSanitizedForFilenames(t *testing.T) {
 	for _, f := range zr.File {
 		if strings.ContainsAny(f.Name, `/\"`+" ") {
 			t.Errorf("zip entry name %q contains unsafe character", f.Name)
+		}
+	}
+}
+
+// TestConcurrencyLimiterReturns429 verifies that concurrencyLimiter
+// rejects excess concurrent requests with HTTP 429 + Retry-After once
+// its capacity is exhausted and the acquire timeout elapses. This
+// guards the /mudzip endpoint against CPU exhaustion via concurrent
+// CMS/ECDSA work (CWE-770, issue #23).
+func TestConcurrencyLimiterReturns429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	// Capacity 1 + tiny timeout so we deterministically force a reject
+	// on the second concurrent request without slowing the test suite.
+	r.Use(concurrencyLimiter(1, 20*time.Millisecond))
+
+	// Block the slot until the test releases it, so the second request
+	// is forced to wait past the acquire timeout.
+	release := make(chan struct{})
+	r.GET("/slow", func(c *gin.Context) {
+		<-release
+		c.Status(http.StatusOK)
+	})
+
+	// Fire request #1 in the background; it holds the only slot.
+	started := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+		w := httptest.NewRecorder()
+		close(started)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("first request status = %d, want 200", w.Code)
+		}
+	}()
+	<-started
+	// Give the first request a moment to enter the limiter before
+	// issuing the second; otherwise both may race for the slot.
+	time.Sleep(5 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request status = %d, want 429", w.Code)
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Errorf("Retry-After header missing on 429 response")
+	}
+
+	close(release)
+	wg.Wait()
+}
+
+// TestConcurrencyLimiterServesSequentialRequests confirms that after a
+// blocked request completes, the slot is released and subsequent
+// requests succeed normally (the semaphore is not leaked).
+func TestConcurrencyLimiterServesSequentialRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(concurrencyLimiter(1, 50*time.Millisecond))
+	r.GET("/ok", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("iteration %d: status = %d, want 200", i, w.Code)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #23 (CWE-770).

Each `/mudzip` request performs three ECDSA key generations plus a CMS sign — all CPU-bound. Without a concurrency cap, a small burst of concurrent callers saturates the host.

## Change

- New `concurrencyLimiter` gin middleware in `web/mudzipserver.go` backed by a buffered-channel semaphore of size `runtime.NumCPU()`.
- Excess requests wait up to 100 ms for a slot; if none frees, they receive **HTTP 429** with a `Retry-After: 1` header so well-behaved clients back off instead of piling on more crypto work.
- Slot is released via `defer`, so the semaphore cannot leak. Client cancellations are handled (status 499) so they don't hold a slot either.
- Wired into `main()` immediately after the existing `limitBody` middleware.

## Operational note

The in-process cap protects the process itself. Operators should still run mudzipserver behind a reverse proxy that enforces per-IP rate limits — captured in the commit message and the issue's remediation guidance.

## Tests

Two new tests in `web/mudzipserver_test.go`:

- `TestConcurrencyLimiterReturns429` — capacity 1, holds the slot in a background goroutine, asserts a second concurrent request gets 429 with a `Retry-After` header.
- `TestConcurrencyLimiterServesSequentialRequests` — confirms slots are released so sequential requests still succeed (no semaphore leak).

`go test ./web/...`, `go build ./...`, and `go vet ./...` all pass.
