### PR TITLE
fix: address lint findings (gosec/errcheck/staticcheck)

### DIFF
--- a/cli/mkmudcerts.go
+++ b/cli/mkmudcerts.go
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package main
+
 /*
 mkmudcerts takes as input product information and generates a set of
 certificates and keys.
@@ -43,8 +44,8 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 	"log"
-	. "github.com/iot-onboarding/mudcerts"
 )
 
 func main() {
@@ -54,12 +55,12 @@ func main() {
 	model := flag.String("mod", "Hornblower 2000", "Device Model")
 	mudurl := flag.String("mudurl", "https://...", "URL for MUDfile")
 	sernum := flag.String("ser", "SN12345", "A device Serial Number")
-	emailaddr := flag.String("email","user@mudsigner.example.com",
+	emailaddr := flag.String("email", "user@mudsigner.example.com",
 		"An email address as a SubjectAltName")
 
 	flag.Parse()
 
-	pinfo := ProductInfo{
+	pinfo := mudcerts.ProductInfo{
 		Manufacturer: *mfg,
 		CountryCode:  *mfgCC,
 		Model:        *model,
@@ -68,7 +69,7 @@ func main() {
 		EmailAddress: *emailaddr,
 	}
 
-	cabytes, caPrivKey, err := GenCA(pinfo)
+	cabytes, caPrivKey, err := mudcerts.GenCA(pinfo)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -78,24 +79,24 @@ func main() {
 		log.Fatal(err)
 	}
 
-	capem := MakePEM(cabytes, "CERTIFICATE")
-	mudcert, mudcertPrivKey, err := MakeMUDcert(pinfo, cacert, caPrivKey)
+	capem := mudcerts.MakePEM(cabytes, "CERTIFICATE")
+	mudcert, mudcertPrivKey, err := mudcerts.MakeMUDcert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		log.Fatal(err)
 	}
-	mudsigner, mudsignerPrivKey, err := MakeSignerCert(pinfo, cacert, caPrivKey)
+	mudsigner, mudsignerPrivKey, err := mudcerts.MakeSignerCert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	mudcertpem := MakePEM(mudcert, "CERTIFICATE")
+	mudcertpem := mudcerts.MakePEM(mudcert, "CERTIFICATE")
 	caPrivBytes, _ := x509.MarshalECPrivateKey(caPrivKey)
-	caPrivkeyPEM := MakePEM(caPrivBytes, "PRIVATE KEY")
+	caPrivkeyPEM := mudcerts.MakePEM(caPrivBytes, "PRIVATE KEY")
 	mudPrivBytes, _ := x509.MarshalECPrivateKey(mudcertPrivKey)
-	mudPrivKeyPEM := MakePEM(mudPrivBytes, "PRIVATE KEY")
-	mudsignerPEM := MakePEM(mudsigner, "CERTIFICATE")
+	mudPrivKeyPEM := mudcerts.MakePEM(mudPrivBytes, "PRIVATE KEY")
+	mudsignerPEM := mudcerts.MakePEM(mudsigner, "CERTIFICATE")
 	mudsignerPrivBytes, _ := x509.MarshalECPrivateKey(mudsignerPrivKey)
-	mudsignerPrivKeyPEM := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	mudsignerPrivKeyPEM := mudcerts.MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
 
 	fmt.Println(capem)
 	fmt.Println(caPrivkeyPEM)

--- a/sign/signmudfile.go
+++ b/sign/signmudfile.go
@@ -41,7 +41,7 @@ import (
 	"os"
 	"regexp"
 
-	. "github.com/iot-onboarding/mudcerts"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 )
 
 // outExt strips the final extension and replaces it with .p7s.
@@ -100,11 +100,14 @@ func signFile(in string, cert *x509.Certificate, key *ecdsa.PrivateKey) error {
 		return fmt.Errorf("read mud file %s: %w", in, err)
 	}
 	out := outExt.ReplaceAllLiteralString(in, "") + ".p7s"
-	der, err := SignMudFile(string(mudfile), cert, key)
+	der, err := mudcerts.SignMudFile(string(mudfile), cert, key)
 	if err != nil {
 		return fmt.Errorf("sign %s: %w", in, err)
 	}
-	if err := os.WriteFile(out, der, 0o600); err != nil {
+	// G703: out is derived from the operator-supplied input path on the
+	// command line; writing the signature next to it is the documented
+	// behavior of this CLI.
+	if err := os.WriteFile(out, der, 0o600); err != nil { //nolint:gosec
 		return fmt.Errorf("write %s: %w", out, err)
 	}
 	return nil

--- a/sign/signmudfile_test.go
+++ b/sign/signmudfile_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	cms "github.com/github/smimesign/ietf-cms"
-	. "github.com/iot-onboarding/mudcerts"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 )
 
 // signFixture generates a CA + signer cert and writes signer.pem +
@@ -33,14 +33,14 @@ import (
 // CA cert (for verifying signatures produced by signAll).
 func signFixture(t *testing.T, dir string) (certPath, keyPath string, caCert *x509.Certificate) {
 	t.Helper()
-	p := ProductInfo{
+	p := mudcerts.ProductInfo{
 		Manufacturer: "ACME",
 		CountryCode:  "US",
 		Model:        "Device1",
 		MudUrl:       "https://example.com/mud/Device1",
 		EmailAddress: "signer@example.com",
 	}
-	caBytes, caKey, err := GenCA(p)
+	caBytes, caKey, err := mudcerts.GenCA(p)
 	if err != nil {
 		t.Fatalf("GenCA: %v", err)
 	}
@@ -48,16 +48,16 @@ func signFixture(t *testing.T, dir string) (certPath, keyPath string, caCert *x5
 	if err != nil {
 		t.Fatalf("ParseCertificate CA: %v", err)
 	}
-	signerBytes, signerKey, err := MakeSignerCert(p, caCert, caKey)
+	signerBytes, signerKey, err := mudcerts.MakeSignerCert(p, caCert, caKey)
 	if err != nil {
 		t.Fatalf("MakeSignerCert: %v", err)
 	}
-	signerPEM := MakePEM(signerBytes, "CERTIFICATE")
+	signerPEM := mudcerts.MakePEM(signerBytes, "CERTIFICATE")
 	keyDER, err := x509.MarshalECPrivateKey(signerKey)
 	if err != nil {
 		t.Fatalf("MarshalECPrivateKey: %v", err)
 	}
-	keyPEM := MakePEM(keyDER, "EC PRIVATE KEY")
+	keyPEM := mudcerts.MakePEM(keyDER, "EC PRIVATE KEY")
 
 	certPath = filepath.Join(dir, "signer.pem")
 	keyPath = filepath.Join(dir, "signer.key")

--- a/verify/verifymudsig.go
+++ b/verify/verifymudsig.go
@@ -60,7 +60,10 @@ func loadPEMCerts(path string) ([]*x509.Certificate, error) {
 	if path == "" {
 		return nil, errors.New("empty path")
 	}
-	data, err := os.ReadFile(path)
+	// G304: path is supplied by the operator via a CLI flag (-ca / -int);
+	// loading the file they pointed at is the documented purpose of this
+	// tool.
+	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
@@ -131,11 +134,11 @@ func verify(caPath, intPath, sigPath, mudPath string, now time.Time) error {
 		return err
 	}
 
-	sig, err := os.ReadFile(sigPath)
+	sig, err := os.ReadFile(sigPath) //nolint:gosec // CLI -sig flag
 	if err != nil {
 		return fmt.Errorf("read sig %s: %w", sigPath, err)
 	}
-	mudfile, err := os.ReadFile(mudPath)
+	mudfile, err := os.ReadFile(mudPath) //nolint:gosec // CLI positional arg
 	if err != nil {
 		return fmt.Errorf("read mud file %s: %w", mudPath, err)
 	}

--- a/verify/verifymudsig_test.go
+++ b/verify/verifymudsig_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/iot-onboarding/mudcerts"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 )
 
 // fixtures holds an in-memory set of generated artifacts plus the
@@ -44,7 +44,7 @@ type fixtures struct {
 func newFixtures(t *testing.T) *fixtures {
 	t.Helper()
 	dir := t.TempDir()
-	pinfo := ProductInfo{
+	pinfo := mudcerts.ProductInfo{
 		Manufacturer: "Test Co",
 		CountryCode:  "US",
 		Model:        "TestModel",
@@ -53,7 +53,7 @@ func newFixtures(t *testing.T) *fixtures {
 		SerialNumber: "SN-1",
 	}
 
-	caBytes, caKey, err := GenCA(pinfo)
+	caBytes, caKey, err := mudcerts.GenCA(pinfo)
 	if err != nil {
 		t.Fatalf("GenCA: %v", err)
 	}
@@ -62,7 +62,7 @@ func newFixtures(t *testing.T) *fixtures {
 		t.Fatalf("ParseCertificate(ca): %v", err)
 	}
 
-	signerBytes, signerKey, err := MakeSignerCert(pinfo, caCert, caKey)
+	signerBytes, signerKey, err := mudcerts.MakeSignerCert(pinfo, caCert, caKey)
 	if err != nil {
 		t.Fatalf("MakeSignerCert: %v", err)
 	}
@@ -72,7 +72,7 @@ func newFixtures(t *testing.T) *fixtures {
 	}
 
 	mud := []byte(`{"ietf-mud:mud":{"mud-version":1,"mud-url":"https://example.com/test.json"}}`)
-	sig, err := SignMudFile(string(mud), signerCert, signerKey)
+	sig, err := mudcerts.SignMudFile(string(mud), signerCert, signerKey)
 	if err != nil {
 		t.Fatalf("SignMudFile: %v", err)
 	}
@@ -85,8 +85,8 @@ func newFixtures(t *testing.T) *fixtures {
 		return p
 	}
 
-	caPath := writeFile("ca.pem", MakePEM(caBytes, "CERTIFICATE").Bytes())
-	signerPath := writeFile("signer.pem", MakePEM(signerBytes, "CERTIFICATE").Bytes())
+	caPath := writeFile("ca.pem", mudcerts.MakePEM(caBytes, "CERTIFICATE").Bytes())
+	signerPath := writeFile("signer.pem", mudcerts.MakePEM(signerBytes, "CERTIFICATE").Bytes())
 	sigPath := writeFile("mudfile.p7s", sig)
 	mudPath := writeFile("mud.json", mud)
 

--- a/web/mudzipserver.go
+++ b/web/mudzipserver.go
@@ -47,7 +47,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	. "github.com/iot-onboarding/mudcerts"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 )
 
 // maxRequestBytes caps the size of any incoming request body. A MUD file
@@ -153,12 +153,12 @@ func printableField(s string, max int) bool {
 // validateProductInfo enforces server-side constraints on every field
 // before any crypto or zip work is performed. Returning a descriptive
 // error lets the caller surface a 400 to the client.
-func validateProductInfo(p ProductInfo) error {
+func validateProductInfo(p mudcerts.ProductInfo) error {
 	if !printableField(p.Model, 64) {
-		return errors.New("Model must be 1-64 printable characters")
+		return errors.New("model must be 1-64 printable characters")
 	}
 	if !printableField(p.Manufacturer, 64) {
-		return errors.New("Manufacturer must be 1-64 printable characters")
+		return errors.New("manufacturer must be 1-64 printable characters")
 	}
 	if len(p.CountryCode) != 2 ||
 		p.CountryCode[0] < 'A' || p.CountryCode[0] > 'Z' ||
@@ -176,7 +176,7 @@ func validateProductInfo(p ProductInfo) error {
 	}
 	u, err := url.Parse(p.MudUrl)
 	if err != nil || u.Scheme != "https" || u.Host == "" {
-		return errors.New("MudUrl must be a valid https:// URL")
+		return errors.New("mudUrl must be a valid https:// URL")
 	}
 	if p.EmailAddress != "" {
 		if !printableField(p.EmailAddress, 254) {
@@ -242,7 +242,7 @@ func httpError(c *gin.Context, status int, msg string, err error) {
 
 // postMUD processes a POST on /mudzip and returns a zip file.
 func postMUD(c *gin.Context) {
-	var pinfo ProductInfo
+	var pinfo mudcerts.ProductInfo
 
 	if err := c.ShouldBindJSON(&pinfo); err != nil {
 		if isBodyTooLarge(err) {
@@ -264,7 +264,7 @@ func postMUD(c *gin.Context) {
 		return
 	}
 
-	cabytes, caPrivKey, err := GenCA(pinfo)
+	cabytes, caPrivKey, err := mudcerts.GenCA(pinfo)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to generate CA", err)
 		return
@@ -276,46 +276,46 @@ func postMUD(c *gin.Context) {
 		return
 	}
 
-	capem := MakePEM(cabytes, "CERTIFICATE")
-	mudcert, mudcertPrivKey, err := MakeMUDcert(pinfo, cacert, caPrivKey)
+	capem := mudcerts.MakePEM(cabytes, "CERTIFICATE")
+	mudcert, mudcertPrivKey, err := mudcerts.MakeMUDcert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to create MUD certificate", err)
 		return
 	}
 
-	mudsigner, mudsignerPrivKey, err := MakeSignerCert(pinfo, cacert, caPrivKey)
+	mudsigner, mudsignerPrivKey, err := mudcerts.MakeSignerCert(pinfo, cacert, caPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to create MUD signer certificate", err)
 		return
 	}
 
-	mudcertpem := MakePEM(mudcert, "CERTIFICATE")
-	mudsignerpem := MakePEM(mudsigner, "CERTIFICATE")
+	mudcertpem := mudcerts.MakePEM(mudcert, "CERTIFICATE")
+	mudsignerpem := mudcerts.MakePEM(mudsigner, "CERTIFICATE")
 	caPrivBytes, err := x509.MarshalECPrivateKey(caPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal CA private key", err)
 		return
 	}
-	caPrivkeyPEM := MakePEM(caPrivBytes, "PRIVATE KEY")
+	caPrivkeyPEM := mudcerts.MakePEM(caPrivBytes, "PRIVATE KEY")
 	mudPrivBytes, err := x509.MarshalECPrivateKey(mudcertPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal MUD private key", err)
 		return
 	}
-	mudPrivKeyPEM := MakePEM(mudPrivBytes, "PRIVATE KEY")
+	mudPrivKeyPEM := mudcerts.MakePEM(mudPrivBytes, "PRIVATE KEY")
 	mudsignerPrivBytes, err := x509.MarshalECPrivateKey(mudsignerPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to marshal MUD signer private key", err)
 		return
 	}
-	mudsignerPrivKeyPEM := MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
+	mudsignerPrivKeyPEM := mudcerts.MakePEM(mudsignerPrivBytes, "PRIVATE KEY")
 
 	mudsigncert, err := x509.ParseCertificate(mudsigner)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to parse MUD signer certificate", err)
 		return
 	}
-	mudsig, err := SignMudFile(string(mudjson), mudsigncert, mudsignerPrivKey)
+	mudsig, err := mudcerts.SignMudFile(string(mudjson), mudsigncert, mudsignerPrivKey)
 	if err != nil {
 		httpError(c, http.StatusInternalServerError, "failed to sign MUD file", err)
 		return
@@ -379,9 +379,13 @@ func postMUD(c *gin.Context) {
 func main() {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.Default()
-	router.SetTrustedProxies(nil)
+	if err := router.SetTrustedProxies(nil); err != nil {
+		log.Fatalf("mudzip: SetTrustedProxies: %v", err)
+	}
 	router.Use(limitBody(maxRequestBytes))
 	router.Use(concurrencyLimiter(runtime.NumCPU(), acquireTimeout))
 	router.POST("/mudzip", postMUD)
-	router.Run(":8085")
+	if err := router.Run(":8085"); err != nil {
+		log.Fatalf("mudzip: Run: %v", err)
+	}
 }

--- a/web/mudzipserver_test.go
+++ b/web/mudzipserver_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	. "github.com/iot-onboarding/mudcerts"
+	mudcerts "github.com/iot-onboarding/mudcerts"
 )
 
 // newTestRouter builds a gin router wired up the same way main() does,
@@ -44,7 +44,7 @@ func newTestRouter() *gin.Engine {
 func TestPostMUDProducesZip(t *testing.T) {
 	mudjson := `{"ietf-mud:mud":{"mud-version":1,"mud-url":"https://example.com/test.json"}}`
 
-	pinfo := ProductInfo{
+	pinfo := mudcerts.ProductInfo{
 		Manufacturer: "ACME Supplies",
 		Model:        "TestDevice",
 		CountryCode:  "US",
@@ -106,7 +106,7 @@ func TestPostMUDProducesZip(t *testing.T) {
 			continue
 		}
 		data, err := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		if err != nil {
 			t.Errorf("read %q: %v", name, err)
 			continue
@@ -125,7 +125,7 @@ func TestPostMUDProducesZip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open mud json: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	data, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("read mud json: %v", err)
@@ -160,7 +160,7 @@ func TestREADMEOpensslVerifyHasBinary(t *testing.T) {
 			t.Fatalf("open README.txt: %v", err)
 		}
 		readme, err = io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		if err != nil {
 			t.Fatalf("read README.txt: %v", err)
 		}
@@ -201,9 +201,9 @@ func TestPostMUDBodyTooLarge(t *testing.T) {
 
 // validPInfo returns a ProductInfo that passes validateProductInfo, so
 // individual tests can mutate one field to exercise a single rule.
-func validPInfo() ProductInfo {
+func validPInfo() mudcerts.ProductInfo {
 	mudjson := `{"ietf-mud:mud":{"mud-version":1,"mud-url":"https://example.com/test.json"}}`
-	return ProductInfo{
+	return mudcerts.ProductInfo{
 		Manufacturer: "ACME Supplies",
 		Model:        "TestDevice",
 		CountryCode:  "US",
@@ -214,7 +214,7 @@ func validPInfo() ProductInfo {
 	}
 }
 
-func postPInfo(t *testing.T, p ProductInfo) *httptest.ResponseRecorder {
+func postPInfo(t *testing.T, p mudcerts.ProductInfo) *httptest.ResponseRecorder {
 	t.Helper()
 	body, err := json.Marshal(p)
 	if err != nil {
@@ -233,21 +233,21 @@ func postPInfo(t *testing.T, p ProductInfo) *httptest.ResponseRecorder {
 func TestValidateProductInfoRejects(t *testing.T) {
 	cases := []struct {
 		name string
-		mut  func(p *ProductInfo)
+		mut  func(p *mudcerts.ProductInfo)
 	}{
-		{"empty Model", func(p *ProductInfo) { p.Model = "" }},
-		{"Model with CRLF", func(p *ProductInfo) { p.Model = "x\r\ny" }},
-		{"Model too long", func(p *ProductInfo) { p.Model = strings.Repeat("a", 65) }},
-		{"empty Manufacturer", func(p *ProductInfo) { p.Manufacturer = "" }},
-		{"Manufacturer with control char", func(p *ProductInfo) { p.Manufacturer = "ACME\x01" }},
-		{"lowercase CountryCode", func(p *ProductInfo) { p.CountryCode = "us" }},
-		{"3-char CountryCode", func(p *ProductInfo) { p.CountryCode = "USA" }},
-		{"empty CountryCode", func(p *ProductInfo) { p.CountryCode = "" }},
-		{"http MudUrl", func(p *ProductInfo) { p.MudUrl = "http://example.com/x.json" }},
-		{"non-URL MudUrl", func(p *ProductInfo) { p.MudUrl = "not a url" }},
-		{"empty MudUrl", func(p *ProductInfo) { p.MudUrl = "" }},
-		{"bad EmailAddress", func(p *ProductInfo) { p.EmailAddress = "not-an-email" }},
-		{"empty Mudfile", func(p *ProductInfo) { p.Mudfile = "" }},
+		{"empty Model", func(p *mudcerts.ProductInfo) { p.Model = "" }},
+		{"Model with CRLF", func(p *mudcerts.ProductInfo) { p.Model = "x\r\ny" }},
+		{"Model too long", func(p *mudcerts.ProductInfo) { p.Model = strings.Repeat("a", 65) }},
+		{"empty Manufacturer", func(p *mudcerts.ProductInfo) { p.Manufacturer = "" }},
+		{"Manufacturer with control char", func(p *mudcerts.ProductInfo) { p.Manufacturer = "ACME\x01" }},
+		{"lowercase CountryCode", func(p *mudcerts.ProductInfo) { p.CountryCode = "us" }},
+		{"3-char CountryCode", func(p *mudcerts.ProductInfo) { p.CountryCode = "USA" }},
+		{"empty CountryCode", func(p *mudcerts.ProductInfo) { p.CountryCode = "" }},
+		{"http MudUrl", func(p *mudcerts.ProductInfo) { p.MudUrl = "http://example.com/x.json" }},
+		{"non-URL MudUrl", func(p *mudcerts.ProductInfo) { p.MudUrl = "not a url" }},
+		{"empty MudUrl", func(p *mudcerts.ProductInfo) { p.MudUrl = "" }},
+		{"bad EmailAddress", func(p *mudcerts.ProductInfo) { p.EmailAddress = "not-an-email" }},
+		{"empty Mudfile", func(p *mudcerts.ProductInfo) { p.Mudfile = "" }},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Closes #41

Addresses the lint findings surfaced by golangci-lint in PR #40's CI run. Split out per the issue so the CI-hardening PR stays focused on infrastructure and this PR stays focused on code cleanup.

## Changes (7 files, +82/-71)

**ST1001 — dot imports**
Replace `. "github.com/iot-onboarding/mudcerts"` with an aliased import `mudcerts "github.com/iot-onboarding/mudcerts"` in `cli/`, `sign/`, `verify/`, and `web/`; qualify all referenced identifiers (`ProductInfo`, `GenCA`, `MakePEM`, `MakeMUDcert`, `MakeSignerCert`, `SignMudFile`) via `gofmt -r`.

**errcheck**
- `web/mudzipserver.go`: `router.SetTrustedProxies(nil)` and `router.Run(":8085")` now `log.Fatalf` on error instead of silently discarding the return.
- `web/mudzipserver_test.go`: three `rc.Close()` (zip ReadCloser) calls now explicitly discard via `_ = rc.Close()` / `defer func() { _ = rc.Close() }()`.

**gosec G304 / G703**
The CLI binaries in `sign/` and `verify/` exist specifically to read and write operator-supplied file paths. Cleaning the paths or restricting their location would defeat the tools' purpose, so the call sites carry `//nolint:gosec` directives with rationale rather than spurious sanitization:
- `sign/signmudfile.go`: `os.WriteFile(out, ...)` where `out` is derived from the input path.
- `verify/verifymudsig.go`: `os.ReadFile` of the `-ca`/`-int`/`-sig` flag values and the positional MUD-file argument.

**ST1005 — error string capitalization**
`validateProductInfo` in `web/mudzipserver.go`: `"Model must be..."` → `"model must be..."`, similarly for `Manufacturer` and `MudUrl`.

## Verification
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all packages pass

golangci-lint coverage will land on this branch once #40 merges; the targeted findings from that PR's CI run are addressed here.
